### PR TITLE
Language update 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,19 @@ nix:
 
 No exports are assumed, as they're bundled into one file (`Main.hs`):
 
-```hs
+```yaml
 ghc-options:
 - -Wno-missing-export-lists
+```
+
+We're using `Haskell2010` because `haskell-src-exts` (the parser) does not understand it, but all the extensions enabled by `haskell-src-exts` are enabled as `default-extensison`:
+
+```yaml
+language: Haskell2010
+
+default-extensions:
+- BangPatterns
+# and lots more
 ```
 
 ### `hacddock`
@@ -66,11 +76,22 @@ ghc-options:
 
 ### GHC version
 
-FIXME: It's not compatible with AtCoder GHC version.
+GHC 9.4.5, [lts-21.6](https://www.stackage.org/lts-21.6).
 
 ### Incremental builds?
 
 TODO
+
+### Limitations
+
+We have limitations coming from [haskell-src-exts](https://github.com/haskell-suite/haskell-src-exts):
+
+- Can't use `MultiWayIf`
+  `haskell-src-exts` does not understand it well.
+
+- Can't use `GHC2021` syntax
+  For example `import X qualified as Y` is not available.
+  > But [the default language extensisons enabled by `GHC2021`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021) is supported and needs not to be declared.
 
 ## Thanks
 

--- a/package.yaml
+++ b/package.yaml
@@ -19,10 +19,57 @@ extra-source-files:
 # common to point users to the README.md file.
 description:         For more info, see Github <https://github.com/toyboot4e/toy-lib>
 
-# REMARK: Because `haskell-src-exts` (the parser) does NOT understand `GHC2021`, we can't used the
-# fancy syntax such as `import X qualifieid as Y`, but we can omit default langauge extensions in
-# `GHC2021`.
-language: GHC2021
+# Because `haskell-src-exts` (the parser) does NOT understand `GHC2021`, we're using `Haskell2010`:
+language: Haskell2010
+
+# But allow `GHC2021` extensions as it's enabled on AtCoder:
+default-extensions:
+- BangPatterns
+- BinaryLiterals
+- ConstrainedClassMethods
+- ConstraintKinds
+- DeriveDataTypeable
+- DeriveFoldable
+- DeriveFunctor
+- DeriveGeneric
+- DeriveLift
+- DeriveTraversable
+- DoAndIfThenElse
+- EmptyCase
+- EmptyDataDecls
+- EmptyDataDeriving
+- ExistentialQuantification
+- ExplicitForAll
+- FieldSelectors
+- FlexibleContexts
+- FlexibleInstances
+- ForeignFunctionInterface
+- GADTSyntax
+- GeneralisedNewtypeDeriving
+- HexFloatLiterals
+- ImplicitPrelude
+- ImportQualifiedPost
+- InstanceSigs
+- KindSignatures
+- MonomorphismRestriction
+- MultiParamTypeClasses
+- NamedFieldPuns
+- NamedWildCards
+- NumericUnderscores
+- PatternGuards
+- PolyKinds
+- PostfixOperators
+- RankNTypes
+- RelaxedPolyRec
+- ScopedTypeVariables
+- StandaloneDeriving
+- StandaloneKindSignatures
+- StarIsType
+- TraditionalRecordSyntax
+- TupleSections
+- TypeApplications
+- TypeOperators
+- TypeSynonymInstances
 
 # On AtCoder:
 # optimization: 2

--- a/package.yaml
+++ b/package.yaml
@@ -19,9 +19,18 @@ extra-source-files:
 # common to point users to the README.md file.
 description:         For more info, see Github <https://github.com/toyboot4e/toy-lib>
 
+# REMARK: Because `haskell-src-exts` (the parser) does NOT understand `GHC2021`, we can't used the
+# fancy syntax such as `import X qualifieid as Y`, but we can omit default langauge extensions in
+# `GHC2021`.
+language: GHC2021
+
+# On AtCoder:
+# optimization: 2
+
+# See also: <https://docs.google.com/spreadsheets/d/1HXyOXt5bKwhKWXruzUvfMFHQtBxfZQ0047W7VVObnXI/edit#gid=408033513&range=J38>
 dependencies:
 - array
-- base >= 4.7 && < 5
+- base
 - bytestring
 - containers
 - extra

--- a/src/Algorithm/BinarySearch.hs
+++ b/src/Algorithm/BinarySearch.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | \(O(log N)\) binary search for sorted items in an inclusive range (from left to right only).
 --

--- a/src/Algorithm/BinarySearch.hs
+++ b/src/Algorithm/BinarySearch.hs
@@ -129,7 +129,7 @@ compressList :: [Int] -> (VU.Vector Int, [Int])
 compressList xs = (indices, map (fromJust . fst . f) xs)
   where
     !indices = VU.fromList $ nubSort xs
-    f !x = bsearch (0, pred (vLength indices)) $ \i -> indices VU.! i <= x
+    f !x = bsearch (0, pred (VU.length indices)) $ \i -> indices VU.! i <= x
 
 -- | Retrieves square root of an `Int`.
 isqrtSlow :: Int -> Int

--- a/src/Algorithm/Imos.hs
+++ b/src/Algorithm/Imos.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | The Imos's algorithm template for 2D grids.
 
 module Algorithm.Imos where

--- a/src/Data/BinaryLifting.hs
+++ b/src/Data/BinaryLifting.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 -- | Binary lifting is a technique for calculating nth power of a semigroup element in a (big)
 -- constant time, or applying them to their semigroup action target.
 --

--- a/src/Data/BitSet.hs
+++ b/src/Data/BitSet.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 -- | Bit set tricks
 module Data.BitSet where
 

--- a/src/Data/Buffer.hs
+++ b/src/Data/Buffer.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 -- | [Data.Buffer](https://github.com/cojna/iota/blob/master/src/Data/Buffer.hs) taken from [cojna/iota](https://github.com/cojna/iota) (thanks!)
 
 module Data.Buffer where

--- a/src/Data/Graph.hs
+++ b/src/Data/Graph.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- | I'm using @Array Int [Int]@ as a primary `Graph` data storage.
 module Data.Graph where
 

--- a/src/Data/Graph/Digraph.hs
+++ b/src/Data/Graph/Digraph.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Digraph coloring.
 --
 -- = Typical problems

--- a/src/Data/Graph/FloydWarshall.hs
+++ b/src/Data/Graph/FloydWarshall.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- | Calculates every shortest path between two vertices (Floyd-Warshall algorithm).
 --
 -- - NOTE: It's slow. Prefer Dijkstra when possible.

--- a/src/Data/Graph/MaxFlow.hs
+++ b/src/Data/Graph/MaxFlow.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Maximum flow calculation (Ford-Fulkerson algorithm).

--- a/src/Data/Graph/MaxFlow.hs
+++ b/src/Data/Graph/MaxFlow.hs
@@ -74,7 +74,6 @@ buildRN !nVerts !edges = do
 {-# INLINE maxFlowRN #-}
 maxFlowRN :: Int -> ResidualNetwork -> Int -> Int -> IO Int
 maxFlowRN !nVerts !rn !v0 !ve = do
-  -- TODO: use BitVec in 2023 environment
   !vis <- VM.replicate nVerts False
   inner vis
   where

--- a/src/Data/Graph/Scc.hs
+++ b/src/Data/Graph/Scc.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE RankNTypes #-}
-
 -- | Strongly connected components and topological sort.
 module Data.Graph.Scc where
 

--- a/src/Data/Graph/Sparse.hs
+++ b/src/Data/Graph/Sparse.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | `vector`-based sparse graph implementation (weightened or unweightened).
 --

--- a/src/Data/ModInt.hs
+++ b/src/Data/ModInt.hs
@@ -1,16 +1,9 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | `Int` with automatic moudlo arithmetic performed. Depends on @Math.PowMod@.
 module Data.ModInt where
 
-import Control.Monad
 import Data.Coerce
 import Data.Proxy
 import qualified Data.Ratio as Ratio

--- a/src/Data/ModInt.hs
+++ b/src/Data/ModInt.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | `Int` with automatic moudlo arithmetic performed. Depends on @Math.PowMod@.
@@ -9,11 +10,12 @@ import Data.Proxy
 import qualified Data.Ratio as Ratio
 import Data.Semigroup
 import Data.SemigroupAction
-import Data.Vector.Generic as VG
-import Data.Vector.Generic.Mutable as VGM
-import Data.Vector.Unboxed as VU
--- import Data.Vector.Unboxed.Deriving (derivingUnbox)
-import Data.Vector.Unboxed.Mutable as VUM
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Unboxed.Base as VU
+import qualified Data.Vector.Unboxed.Mutable as VUM
 import Math.PowMod (invModF)
 
 -- | Type level constant `Int` value.
@@ -23,7 +25,7 @@ class TypeInt a where
 
 -- | `Int` with automatic moudlo arithmetic performed.
 newtype ModInt p = ModInt {toInt :: Int}
-  deriving (Eq)
+  deriving (Eq, VP.Prim)
 
 instance Show (ModInt p) where
   show = show . toInt
@@ -52,57 +54,8 @@ instance (TypeInt p) => Enum (ModInt p) where
 instance TypeInt p => SemigroupAction (Product (ModInt p)) (ModInt p) where
   sact (Product !x1) !x2 = x1 * x2
 
--- derivingUnbox
---   "ModInt"
---   [t|forall p. ModInt p -> Int|]
---   [|\(ModInt !x) -> x|]
---   [|\ !x -> ModInt x|]
-
-newtype instance VUM.MVector s (ModInt p) = MV_ModInt (VUM.MVector s Int)
-
-newtype instance VU.Vector (ModInt p) = V_ModInt (VU.Vector Int)
-
+newtype instance VU.MVector s (ModInt p) = MV_Int (VP.MVector s (ModInt p))
+newtype instance VU.Vector    (ModInt p) = V_Int  (VP.Vector    (ModInt p))
+deriving via (VU.UnboxViaPrim (ModInt p)) instance VGM.MVector VUM.MVector (ModInt p)
+deriving via (VU.UnboxViaPrim (ModInt p)) instance VG.Vector  VU.Vector  (ModInt p)
 instance VU.Unbox (ModInt p)
-
-instance VGM.MVector VUM.MVector (ModInt p) where
-  basicLength (MV_ModInt v) = VGM.basicLength v
-  {-# INLINE basicLength #-}
-  basicUnsafeSlice i n (MV_ModInt v) = MV_ModInt $ VGM.basicUnsafeSlice i n v
-  {-# INLINE basicUnsafeSlice #-}
-  basicOverlaps (MV_ModInt v1) (MV_ModInt v2) = VGM.basicOverlaps v1 v2
-  {-# INLINE basicOverlaps #-}
-  basicUnsafeNew n = MV_ModInt <$> VGM.basicUnsafeNew n
-  {-# INLINE basicUnsafeNew #-}
-  basicInitialize (MV_ModInt v) = VGM.basicInitialize v
-  {-# INLINE basicInitialize #-}
-  basicUnsafeReplicate n x = MV_ModInt <$> VGM.basicUnsafeReplicate n (coerce x)
-  {-# INLINE basicUnsafeReplicate #-}
-  basicUnsafeRead (MV_ModInt v) i = coerce <$> VGM.basicUnsafeRead v i
-  {-# INLINE basicUnsafeRead #-}
-  basicUnsafeWrite (MV_ModInt v) i x = VGM.basicUnsafeWrite v i (coerce x)
-  {-# INLINE basicUnsafeWrite #-}
-  basicClear (MV_ModInt v) = VGM.basicClear v
-  {-# INLINE basicClear #-}
-  basicSet (MV_ModInt v) x = VGM.basicSet v (coerce x)
-  {-# INLINE basicSet #-}
-  basicUnsafeCopy (MV_ModInt v1) (MV_ModInt v2) = VGM.basicUnsafeCopy v1 v2
-  {-# INLINE basicUnsafeCopy #-}
-  basicUnsafeMove (MV_ModInt v1) (MV_ModInt v2) = VGM.basicUnsafeMove v1 v2
-  {-# INLINE basicUnsafeMove #-}
-  basicUnsafeGrow (MV_ModInt v) n = MV_ModInt <$> VGM.basicUnsafeGrow v n
-  {-# INLINE basicUnsafeGrow #-}
-
-instance VG.Vector VU.Vector (ModInt p) where
-  basicUnsafeFreeze (MV_ModInt v) = V_ModInt <$> VG.basicUnsafeFreeze v
-  {-# INLINE basicUnsafeFreeze #-}
-  basicUnsafeThaw (V_ModInt v) = MV_ModInt <$> VG.basicUnsafeThaw v
-  {-# INLINE basicUnsafeThaw #-}
-  basicLength (V_ModInt v) = VG.basicLength v
-  {-# INLINE basicLength #-}
-  basicUnsafeSlice i n (V_ModInt v) = V_ModInt $ VG.basicUnsafeSlice i n v
-  {-# INLINE basicUnsafeSlice #-}
-  basicUnsafeIndexM (V_ModInt v) i = coerce <$> VG.basicUnsafeIndexM v i
-  {-# INLINE basicUnsafeIndexM #-}
-  basicUnsafeCopy (MV_ModInt mv) (V_ModInt v) = VG.basicUnsafeCopy mv v
-  elemseq _ = seq
-  {-# INLINE elemseq #-}

--- a/src/Data/MultiSet.hs
+++ b/src/Data/MultiSet.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Multi set backed by `IntMap`.
 
 module Data.MultiSet where

--- a/src/Data/RollingHash.hs
+++ b/src/Data/RollingHash.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- | The rolling hash algorithm lets you create fastly (\(O(1)\)) comparable / concatanatable string
 -- slice in after \(O(N)\) preparation.
 --

--- a/src/Data/SegmentTree/Lazy.hs
+++ b/src/Data/SegmentTree/Lazy.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- | Lazy segment tree, where we can perform operation over range.
 --
 -- = Typical problems

--- a/src/Data/SegmentTree/Strict.hs
+++ b/src/Data/SegmentTree/Strict.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Data.SegmentTree.Strict where
 
 import Control.Monad.Primitive (PrimMonad, PrimState)

--- a/src/Data/SemigroupAction.hs
+++ b/src/Data/SemigroupAction.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 -- | Semigroup action @*@ is an operator where \(s_2 * (s_1 * a) == (s_2 ⊕ s_1) * a\) holds.
 
 module Data.SemigroupAction where

--- a/src/Data/Tree/Fold.hs
+++ b/src/Data/Tree/Fold.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- | Tree folding.
 
 module Data.Tree.Fold where

--- a/src/Data/Tree/Lca.hs
+++ b/src/Data/Tree/Lca.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Data.Tree.Lca where
 
 import Algorithm.BinarySearch

--- a/src/Data/Unindex.hs
+++ b/src/Data/Unindex.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-
 -- | Handy, more restricted `Data.Ix` with reverse conversion, fast monadic iteration and unboxing.
 module Data.Unindex where
 

--- a/src/Data/UnionFind/Mutable.hs
+++ b/src/Data/UnionFind/Mutable.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/src/Data/UnionFind/Sparse.hs
+++ b/src/Data/UnionFind/Sparse.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 module Data.UnionFind.Sparse where
 
 import Data.List (foldl')

--- a/src/Data/Vector/Compress.hs
+++ b/src/Data/Vector/Compress.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 module Data.Vector.Compress where
 
 import Algorithm.BinarySearch

--- a/src/Data/Vector/Compress.hs
+++ b/src/Data/Vector/Compress.hs
@@ -4,11 +4,11 @@ import Algorithm.BinarySearch
 import Data.List.Extra (nubSort)
 import Data.Maybe
 import qualified Data.Vector.Unboxed as VU
-import ToyLib.Prelude (vLength)
+import ToyLib.Prelude
 
 -- | One dimensional index compression: xs -> (indexer, xs')
 compressVU :: VU.Vector Int -> (VU.Vector Int, VU.Vector Int)
 compressVU xs = (indexer, VU.map (fromJust . fst . f) xs)
   where
     !indexer = VU.fromList $ nubSort $ VU.toList xs
-    f !x = bsearch (0, pred $ vLength indexer) $ \i -> indexer VU.! i <= x
+    f !x = bsearch (0, pred $ VU.length indexer) $ \i -> indexer VU.! i <= x

--- a/src/Data/Vector/DictOrder.hs
+++ b/src/Data/Vector/DictOrder.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Data.Vector.DictOrder where

--- a/src/Data/Vector/InvNum.hs
+++ b/src/Data/Vector/InvNum.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Data.Vector.InvNum where
 

--- a/src/Data/Vector/IxVector.hs
+++ b/src/Data/Vector/IxVector.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | `Ix`-based API over `vector`.

--- a/src/Math/Bits.hs
+++ b/src/Math/Bits.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Obsolute. TODO: Delete.
 
 module Math.Bits where

--- a/src/Math/Digits.hs
+++ b/src/Math/Digits.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Obsolute. TODO: Delete.
 module Math.Digits where
 

--- a/src/Math/Divisors.hs
+++ b/src/Math/Divisors.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | The number of divisor is smaller than \(log N\).
 -- See also: <https://scrapbox.io/magurofly/%E7%B4%84%E6%95%B0%E3%81%AE%E5%80%8B%E6%95%B0%E3%81%AE%E3%82%AA%E3%83%BC%E3%83%80%E3%83%BC>
 --

--- a/src/Math/Manhattan.hs
+++ b/src/Math/Manhattan.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Manhattan distance
 --
 -- = Typical problems

--- a/src/Math/Matrix.hs
+++ b/src/Math/Matrix.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- | TODO: Refactor in my way.
 module Math.Matrix where
 

--- a/src/Math/PowMod.hs
+++ b/src/Math/PowMod.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | TODO, Combine ModInt as Modulo module.
 
 module Math.PowMod where

--- a/src/Math/Primes.hs
+++ b/src/Math/Primes.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 -- | Prime number enumeration and prime factorization.
 
 module Math.Primes where

--- a/src/Math/Primes.hs
+++ b/src/Math/Primes.hs
@@ -6,26 +6,7 @@ import Data.List (group)
 
 -- {{{ Prime factors
 
--- -- @gotoki_no_joe
--- primes :: [Int]
--- primes = 2 : 3 : sieve q0 [5, 7 ..]
---   where
---     q0 = H.insert (H.Entry 9 6) H.empty
---     sieve queue xxs@(x : xs) =
---       case compare np x of
---         LT -> sieve queue1 xxs
---         EQ -> sieve queue1 xs
---         GT -> x : sieve queue2 xs
---       where
---         H.Entry np p2 = H.minimum queue
---         queue1 = H.insert (H.Entry (np + p2) p2) $ H.deleteMin queue
---         queue2 = H.insert (H.Entry (x * x) (x * 2)) queue
---     sieve _ _ = error "unreachale"
-
--- | @0xYusuke
--- <https://zenn.dev/link/comments/1022553732563c>
---
--- TODO: remove `union*` on 2023 update
+-- | @0xYusuke <https://zenn.dev/link/comments/1022553732563c>
 primes :: [Int]
 primes = 2 : 3 : minus [5, 7 ..] (unionAll [[p * p, p * p + 2 * p ..] | p <- tail primes])
   where

--- a/src/ToyLib/Debug.hs
+++ b/src/ToyLib/Debug.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TupleSections #-}
-
 -- | Debug utilities
 module ToyLib.Debug where
 

--- a/src/ToyLib/Macro.hs
+++ b/src/ToyLib/Macro.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 
 -- Excluded on generation

--- a/src/ToyLib/Prelude.hs
+++ b/src/ToyLib/Prelude.hs
@@ -103,32 +103,6 @@ maximumOr !orValue !xs =
     then orValue
     else VU.maximum xs
 
--- | TODO: Remove on 2023 update.
-{-# INLINE unconsVG #-}
-unconsVG :: VG.Vector v a => v a -> Maybe (a, v a)
-unconsVG v
-  | VG.null v = Nothing
-  | otherwise = Just (VG.unsafeHead v, VG.unsafeTail v)
-
--- | TODO: Remove on 2023 langauge update.
--- @since 0.13.0.1
-{-# INLINE groupByVG #-}
-groupByVG :: (VG.Vector v a) => (a -> a -> Bool) -> v a -> [v a]
-groupByVG _ !v | VG.null v = []
-groupByVG !f !v =
-  let !h = VG.unsafeHead v
-      !tl = VG.unsafeTail v
-   in case VG.findIndex (not . f h) tl of
-        Nothing -> [v]
-        Just !n -> VG.unsafeTake (n + 1) v : groupByVG f (VG.unsafeDrop (n + 1) v)
-
--- | TODO: Remove on 2023 langauge update.
--- /O(n)/ Split a vector into a list of slices.
--- @since 0.13.0.1
-{-# INLINE groupVG #-}
-groupVG :: (VG.Vector v a, Eq a) => v a -> [v a]
-groupVG = groupByVG (==)
-
 safeHead :: (VU.Unbox a) => VU.Vector a -> Maybe a
 safeHead vec = if VU.null vec then Nothing else Just $! VU.head vec
 

--- a/src/ToyLib/Prelude.hs
+++ b/src/ToyLib/Prelude.hs
@@ -120,11 +120,6 @@ modifyArray !ary !f !i = do
   !v <- f <$> readArray ary i
   writeArray ary i v
 
--- TODO: Remove on language update
-{-# INLINE vLength #-}
-vLength :: (VG.Vector v e) => v e -> Int
-vLength = VFB.length . VG.stream
-
 {-# INLINE rangeVG #-}
 rangeVG :: (VG.Vector v Int) => Int -> Int -> v Int
 rangeVG !i !j = VG.enumFromN i (succ j - i)

--- a/src/ToyLib/Prelude.hs
+++ b/src/ToyLib/Prelude.hs
@@ -84,13 +84,6 @@ foldForMMS !s0 !xs !f = MS.foldM' f s0 xs
 -- TODO: `minimumMay` from `mono-traversable`?
 -- or copy the `safe` packge: <https://hackage.haskell.org/package/safe-0.3.14/docs/Safe-Foldable.html>
 
--- TODO: 2023 update
--- minimumOr :: (Ord a, Foldable t) => a -> t a -> a
--- minimumOr !orValue !xs =
---   if null xs
---     then orValue
---     else minimum xs
-
 minimumOr :: (Ord a, VU.Unbox a) => a -> VU.Vector a -> a
 minimumOr !orValue !xs =
   if VU.null xs

--- a/src/ToyLib/Prelude.hs
+++ b/src/ToyLib/Prelude.hs
@@ -113,13 +113,6 @@ safeLast vec = if VU.null vec then Nothing else Just $! VU.last vec
 
 -- {{{ Libary complements
 
--- | TODO: Remove on 2023 langauge update (?)
-{-# INLINE modifyArray #-}
-modifyArray :: (MArray a e m, Ix i) => a i e -> (e -> e) -> i -> m ()
-modifyArray !ary !f !i = do
-  !v <- f <$> readArray ary i
-  writeArray ary i v
-
 {-# INLINE rangeVG #-}
 rangeVG :: (VG.Vector v Int) => Int -> Int -> v Int
 rangeVG !i !j = VG.enumFromN i (succ j - i)

--- a/src/ToyLib/Prelude.hs
+++ b/src/ToyLib/Prelude.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 
 module ToyLib.Prelude where
 
@@ -263,7 +260,7 @@ times !n !f !s0 = snd $! until ((== n) . fst) (bimap succ f) (0 :: Int, s0)
 -- - <https://zenn.dev/osushi0x/scraps/51ff0594a1e863#comment-e6b0af9b61c54c>
 combs :: Int -> [a] -> [[a]]
 combs _ [] = error "given empty list"
-combs k as@(!x : xs)
+combs k as@(!_ : xs)
   | k == 0 = [[]]
   | k == 1 = map pure as
   | k == l = pure as

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,8 +22,9 @@ nix:
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/25.yaml
+# resolver:
+#   url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/25.yaml
+resolver: lts-21.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/template/GHC2021.hs
+++ b/template/GHC2021.hs
@@ -1,0 +1,54 @@
+-- | Langauge extensions enabled by `GHC2021`.
+--
+-- This file is for `haskell-src-exts` to parse `GHC2021` Haskell files where the parser do not
+-- understand `GHC2021`, thus manually giving the enabled language extensions.
+
+-- <https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021>
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FieldSelectors #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE HexFloatLiterals #-}
+{-# LANGUAGE ImplicitPrelude #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MonomorphismRestriction #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NamedWildCards #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE PostfixOperators #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RelaxedPolyRec #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE StarIsType #-}
+{-# LANGUAGE TraditionalRecordSyntax #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+

--- a/template/Header.hs
+++ b/template/Header.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env stack
-{- stack script --resolver lts-16.31 --package array --package bytestring --package containers --package extra --package hashable --package unordered-containers --package heaps --package utility-ht --package vector --package vector-th-unbox --package vector-algorithms --package primitive --package transformers --ghc-options "-D DEBUG" -}
+{- stack script --resolver lts-21.6 --package array --package bytestring --package containers --package extra --package hashable --package unordered-containers --package heaps --package utility-ht --package vector --package vector-th-unbox --package vector-algorithms --package primitive --package transformers --ghc-options "-D DEBUG" -}
 {-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-top-binds #-}

--- a/template/Main.hs
+++ b/template/Main.hs
@@ -15,12 +15,6 @@
 {-# LANGUAGE CPP, TemplateHaskell #-}
 {- ORMOLU_ENABLE -}
 
-{- TODO: on 2023 langauge update,
-  - ditch `vector-th-unbox` and `TemplateHaskell`
-  - remove `vLength`
-  - refactor `primes` with new Prelude
--}
-
 -- {{{ Imports
 
 module Template () where

--- a/template/Main.hs
+++ b/template/Main.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
-{- stack script --resolver lts-16.31
+{- stack script --resolver lts-21.6
 --package array --package bytestring --package containers --package extra
 --package hashable --package unordered-containers --package heaps --package utility-ht
 --package vector --package vector-th-unbox --package vector-algorithms --package primitive
@@ -9,11 +9,8 @@
 -}
 
 {- ORMOLU_DISABLE -}
-{-# LANGUAGE BangPatterns, BlockArguments, DefaultSignatures, LambdaCase, MultiWayIf #-}
-{-# LANGUAGE NamedFieldPuns, NumDecimals, NumericUnderscores, PatternGuards, TupleSections #-}
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, InstanceSigs, MultiParamTypeClasses #-}
-{-# LANGUAGE QuantifiedConstraints, RecordWildCards, ScopedTypeVariables, StrictData #-}
-{-# LANGUAGE TypeApplications, TypeFamilies, RankNTypes #-}
+{-# LANGUAGE BlockArguments, DefaultSignatures, LambdaCase, MultiWayIf, NumDecimals #-}
+{-# LANGUAGE QuantifiedConstraints, RecordWildCards, StrictData, TypeFamilies #-}
 
 {-# LANGUAGE CPP, TemplateHaskell #-}
 {- ORMOLU_ENABLE -}

--- a/template/Main.hs
+++ b/template/Main.hs
@@ -9,8 +9,8 @@
 -}
 
 {- ORMOLU_DISABLE -}
-{-# LANGUAGE BlockArguments, DefaultSignatures, LambdaCase, MultiWayIf, NumDecimals #-}
-{-# LANGUAGE QuantifiedConstraints, RecordWildCards, StrictData, TypeFamilies #-}
+{-# LANGUAGE BlockArguments, DefaultSignatures, DerivingVia, LambdaCase, MultiWayIf, NumDecimals #-}
+{-# LANGUAGE QuantifiedConstraints, RecordWildCards, StandaloneDeriving, StrictData, TypeFamilies #-}
 
 {-# LANGUAGE CPP, TemplateHaskell #-}
 {- ORMOLU_ENABLE -}
@@ -92,7 +92,9 @@ import qualified Data.List.HT as HT -- `groupBy`, but with adjacent elements
 import qualified Data.Vector.Fusion.Bundle as VFB
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Generic.Mutable as VGM
+import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Unboxed.Base as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM

--- a/toy-lib.cabal
+++ b/toy-lib.cabal
@@ -67,7 +67,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
   build-depends:
       array
-    , base >=4.7 && <5
+    , base
     , bytestring
     , containers
     , extra
@@ -80,7 +80,7 @@ library
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: Haskell2010
+  default-language: GHC2021
 
 executable toy-lib-exe
   main-is: Main.hs
@@ -91,7 +91,7 @@ executable toy-lib-exe
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array
-    , base >=4.7 && <5
+    , base
     , bytestring
     , containers
     , directory
@@ -110,7 +110,7 @@ executable toy-lib-exe
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: Haskell2010
+  default-language: GHC2021
 
 test-suite toy-lib-test
   type: exitcode-stdio-1.0
@@ -122,7 +122,7 @@ test-suite toy-lib-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array
-    , base >=4.7 && <5
+    , base
     , bytestring
     , containers
     , doctest
@@ -137,4 +137,4 @@ test-suite toy-lib-test
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: Haskell2010
+  default-language: GHC2021

--- a/toy-lib.cabal
+++ b/toy-lib.cabal
@@ -64,6 +64,53 @@ library
       Paths_toy_lib
   hs-source-dirs:
       src
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstrainedClassMethods
+      ConstraintKinds
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DoAndIfThenElse
+      EmptyCase
+      EmptyDataDecls
+      EmptyDataDeriving
+      ExistentialQuantification
+      ExplicitForAll
+      FieldSelectors
+      FlexibleContexts
+      FlexibleInstances
+      ForeignFunctionInterface
+      GADTSyntax
+      GeneralisedNewtypeDeriving
+      HexFloatLiterals
+      ImplicitPrelude
+      ImportQualifiedPost
+      InstanceSigs
+      KindSignatures
+      MonomorphismRestriction
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NamedWildCards
+      NumericUnderscores
+      PatternGuards
+      PolyKinds
+      PostfixOperators
+      RankNTypes
+      RelaxedPolyRec
+      ScopedTypeVariables
+      StandaloneDeriving
+      StandaloneKindSignatures
+      StarIsType
+      TraditionalRecordSyntax
+      TupleSections
+      TypeApplications
+      TypeOperators
+      TypeSynonymInstances
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
   build-depends:
       array
@@ -80,7 +127,7 @@ library
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: GHC2021
+  default-language: Haskell2010
 
 executable toy-lib-exe
   main-is: Main.hs
@@ -88,6 +135,53 @@ executable toy-lib-exe
       Paths_toy_lib
   hs-source-dirs:
       app
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstrainedClassMethods
+      ConstraintKinds
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DoAndIfThenElse
+      EmptyCase
+      EmptyDataDecls
+      EmptyDataDeriving
+      ExistentialQuantification
+      ExplicitForAll
+      FieldSelectors
+      FlexibleContexts
+      FlexibleInstances
+      ForeignFunctionInterface
+      GADTSyntax
+      GeneralisedNewtypeDeriving
+      HexFloatLiterals
+      ImplicitPrelude
+      ImportQualifiedPost
+      InstanceSigs
+      KindSignatures
+      MonomorphismRestriction
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NamedWildCards
+      NumericUnderscores
+      PatternGuards
+      PolyKinds
+      PostfixOperators
+      RankNTypes
+      RelaxedPolyRec
+      ScopedTypeVariables
+      StandaloneDeriving
+      StandaloneKindSignatures
+      StarIsType
+      TraditionalRecordSyntax
+      TupleSections
+      TypeApplications
+      TypeOperators
+      TypeSynonymInstances
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array
@@ -110,7 +204,7 @@ executable toy-lib-exe
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: GHC2021
+  default-language: Haskell2010
 
 test-suite toy-lib-test
   type: exitcode-stdio-1.0
@@ -119,6 +213,53 @@ test-suite toy-lib-test
       Paths_toy_lib
   hs-source-dirs:
       test
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstrainedClassMethods
+      ConstraintKinds
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DoAndIfThenElse
+      EmptyCase
+      EmptyDataDecls
+      EmptyDataDeriving
+      ExistentialQuantification
+      ExplicitForAll
+      FieldSelectors
+      FlexibleContexts
+      FlexibleInstances
+      ForeignFunctionInterface
+      GADTSyntax
+      GeneralisedNewtypeDeriving
+      HexFloatLiterals
+      ImplicitPrelude
+      ImportQualifiedPost
+      InstanceSigs
+      KindSignatures
+      MonomorphismRestriction
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NamedWildCards
+      NumericUnderscores
+      PatternGuards
+      PolyKinds
+      PostfixOperators
+      RankNTypes
+      RelaxedPolyRec
+      ScopedTypeVariables
+      StandaloneDeriving
+      StandaloneKindSignatures
+      StarIsType
+      TraditionalRecordSyntax
+      TupleSections
+      TypeApplications
+      TypeOperators
+      TypeSynonymInstances
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       array
@@ -137,4 +278,4 @@ test-suite toy-lib-test
     , vector
     , vector-algorithms
     , vector-th-unbox
-  default-language: GHC2021
+  default-language: Haskell2010


### PR DESCRIPTION
# Done

- [x] Use GHC 9.4.5 and [lts-21.6](https://www.stackage.org/lts-21.6)!
- [x] [haskell-src-exts](https://github.com/haskell-suite/haskell-src-exts) does not understand `GHC2021`
  Keep using `Haskell2010`, but enable [all the extensions coming from `GHC2021`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html).
- [x] Use `derivingVia` for implementing `Unbox` for `ModInt`
  Still use `derivingUnbox` (`vector-th-unbox`) for sum types
- [x] Remove functions that are in the new packages (`modifyArray`, `ungroupVG` etc.)

# Considerations

- [ ] Use of `Data.List`
